### PR TITLE
fix: use correct endon

### DIFF
--- a/mod/maps/mp/gametypes/dom.gsc
+++ b/mod/maps/mp/gametypes/dom.gsc
@@ -80,6 +80,9 @@ onPlayerSpawned()
 	for(;;)
 	{
 		self waittill("spawned_player");
+
+		self.cj["settings"]["ufo_mode"] = false;
+
 		self thread ammoCheck();
 		self thread setupLoadout();
 		self thread watchMeleeButtonPressed();
@@ -334,7 +337,7 @@ initMenuOpts()
 
 initMenu()
 {
-	self endon("death");
+	self endon("end_respawn");
 	self endon("disconnect");
 
 	level.SCROLL_TIME_SECONDS = 0.15;
@@ -424,7 +427,7 @@ openCJ()
 watchUseButtonPressed()
 {
 	self endon("disconnect");
-	self endon("death");
+	self endon("end_respawn");
 
 	for(;;)
 	{
@@ -528,7 +531,7 @@ createRectangle(align, relative, x, y, width, height, color, shader, sort, alpha
 
 destroyOnDeath(elem)
 {
-	self waittill_any("death", "disconnect");
+	self waittill_any("end_respawn", "disconnect");
 	if(isDefined(elem.bar))
 		elem destroyElem();
 	else
@@ -537,7 +540,7 @@ destroyOnDeath(elem)
 
 ammoCheck()
 {
-	self endon("death");
+	self endon("end_respawn");
 	self endon("disconnect");
 	level endon("game_ended");
 
@@ -607,7 +610,7 @@ setupLoadout()
 watchMeleeButtonPressed()
 {
 	self endon("disconnect");
-	self endon("death");
+	self endon("end_respawn");
 
 	for(;;)
 	{
@@ -637,7 +640,7 @@ watchMeleeButtonPressed()
 watchSecondaryOffhandButtonPressed()
 {
 	self endon("disconnect");
-	self endon("death");
+	self endon("end_respawn");
 
 	for(;;)
 	{
@@ -658,7 +661,7 @@ watchSecondaryOffhandButtonPressed()
 watchFragButtonPressed()
 {
 	self endon("disconnect");
-	self endon("death");
+	self endon("end_respawn");
 
 	for(;;)
 	{
@@ -726,7 +729,7 @@ initBot()
 
 watchDPAD_UP()
 {
-	self endon("death");
+	self endon("end_respawn");
 	self endon("disconnect");
 	level endon("game_ended");
 

--- a/mod/maps/mp/gametypes/koth.gsc
+++ b/mod/maps/mp/gametypes/koth.gsc
@@ -56,7 +56,7 @@ initHeightMeterHudElem()
 
 updateSpeedometerHudElem()
 {
-	self endon("death");
+	self endon("end_respawn");
 	self endon("disconnect");
 	level endon("game_ended");
 
@@ -176,7 +176,7 @@ activeGameObjectMoveOriginZ(z)
 
 forgeMode()
 {
-	self endon("death");
+	self endon("end_respawn");
 	self endon("disconnect");
 	self endon("stop_forge");
 
@@ -246,7 +246,7 @@ toggleRPGSwitch()
 rpgSwitch()
 {
 	self endon("disconnect");
-	self endon("death");
+	self endon("end_respawn");
 
 	self notify("stop_rpg_switch");
 	self endon("stop_rpg_switch");


### PR DESCRIPTION
Addresses #18, should correctly end all necessary threads to prevent them from being ran more than once

Also sets ufo to false upon spawning to ensure things still correctly toggle (if you switched teams while UFO was on, it would still be set to true and you would need to toggle it again for things to work as expected)